### PR TITLE
feat: add translation icon to language menu

### DIFF
--- a/packages/cht_cognition/README.md
+++ b/packages/cht_cognition/README.md
@@ -17,6 +17,7 @@ It demonstrates:
 
 - How to initialize the package
 - How to load translations
+- How to switch between supported languages with the app bar translate icon
 - How to run the cognitive tasks
 
 ## 📦 Installation

--- a/packages/cht_cognition/example/lib/main.dart
+++ b/packages/cht_cognition/example/lib/main.dart
@@ -61,6 +61,7 @@ class _HomePageState extends State<HomePage> {
           PopupMenuButton<Locale?>(
             tooltip: localizations.languageToolTip,
             onSelected: widget.onLocaleChange,
+            icon: const Icon(Icons.translate),
             itemBuilder: (BuildContext context) {
               return <PopupMenuItem<Locale?>>[
                 PopupMenuItem<Locale?>(

--- a/packages/cht_ema_surveys/README.md
+++ b/packages/cht_ema_surveys/README.md
@@ -17,6 +17,7 @@ It demonstrates:
 
 - How to initialize the package
 - How to load translations
+- How to switch between supported languages with the app bar translate icon
 - How to run the surveys
 
 ## 📦 Installation

--- a/packages/cht_ema_surveys/example/lib/main.dart
+++ b/packages/cht_ema_surveys/example/lib/main.dart
@@ -61,6 +61,7 @@ class _HomePageState extends State<HomePage> {
           PopupMenuButton<Locale?>(
             tooltip: localizations.languageToolTip,
             onSelected: widget.onLocaleChange,
+            icon: const Icon(Icons.translate),
             itemBuilder: (BuildContext context) {
               return <PopupMenuItem<Locale?>>[
                 PopupMenuItem<Locale?>(


### PR DESCRIPTION
## Description

- Displays a new language selector icon to the app bar that clearly indicates language-switching functionality.

## Related Issue(s)

Closes #23 

## Packages Affected

<!-- Mark with an `x` all that apply -->

- [X] packages/cht_cognition
- [X] packages/cht_ema_surveys
- [ ] general (monorepo / CI / docs)

## Test Plan

<!-- How did you verify this change? Add precise steps and expected outcomes. -->

- [ ] Unit tests added/updated for new/changed logic
- [X] Example app(s) updated and manually tested

## Impact Checklist

<!-- Mark with an `x` all that apply and add details below when checked -->

- [X] **Feature** (new feature)
- [ ] **Improvement** (improved existing feature, refactor or improve code, measurable performance boost)
- [ ] **Fix** (Fixes a bug)
- [ ] **Public API change** (new/changed parameters, return types, or behavior)
- [ ] **Breaking change** (requires host apps to update code)
- [X] **Docs** (README, example apps, or comments)
- [ ] **Internalization** (language strings updated)
- [ ] **CI/config/chore** (melos, CI workflows, release-drafter, dependencies)
- [ ] **Security** (auth, permissions, secrets)
- [ ] **Other changes** not listed above (explain below)

**Details for any checked items above:**

<!-- Briefly explain the change & migration notes if needed. -->

## Pre-merge Checks

- [X] I read the project's code of conduct (see below)
- [X] I read the contributing guide
- [X] Title follows **type(scope): summary** and will auto-label the PR
- [X] Ran locally: `dart run melos bootstrap`
- [X] Ran code formatter: `dart run melos run analyze`
- [X] Ran static analysis: `dart run melos format`
- [X] Ran tests: `dart run melos run test`
- [X] Checked Android example apps build `dart run melos run build_android_examples`
- [X] Checked iOS example apps build `dart run melos run build_ios_examples`

---

### Contributor Guidelines

By opening this PR you agree to follow our Code of Conduct:
https://www.contributor-covenant.org/version/1/4/code-of-conduct/
