### PR TITLE
feat(surveys): add international physical activity questionnaire in EMA format

### DIFF
--- a/packages/cht_ema_surveys/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/packages/cht_ema_surveys/example/ios/Flutter/AppFrameworkInfo.plist
@@ -20,7 +20,5 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>MinimumOSVersion</key>
-  <string>13.0</string>
 </dict>
 </plist>

--- a/packages/cht_ema_surveys/example/ios/Runner/AppDelegate.swift
+++ b/packages/cht_ema_surveys/example/ios/Runner/AppDelegate.swift
@@ -2,12 +2,15 @@ import Flutter
 import UIKit
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
-    GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+    GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
   }
 }

--- a/packages/cht_ema_surveys/example/ios/Runner/Info.plist
+++ b/packages/cht_ema_surveys/example/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
@@ -24,6 +26,29 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>flutter</string>
+					<key>UISceneDelegateClassName</key>
+					<string>FlutterSceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -41,9 +66,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>CADisableMinimumFrameDurationOnPhone</key>
-	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
 </dict>
 </plist>

--- a/packages/cht_ema_surveys/example/lib/l10n/app_en.arb
+++ b/packages/cht_ema_surveys/example/lib/l10n/app_en.arb
@@ -4,9 +4,9 @@
   "@appTitle": {
     "description": "Title for the app"
   },
-  "homeMessage": "Home screen",
-  "@homeMessage": {
-    "description": "Message displayed on the home screen"
+  "ipaqName": "IPAQ",
+  "@ipaqName": {
+    "description": "IPAQ name displayed on the home screen"
   },
   "languageToolTip": "Select Language",
   "@languageToolTip": {

--- a/packages/cht_ema_surveys/example/lib/l10n/app_es.arb
+++ b/packages/cht_ema_surveys/example/lib/l10n/app_es.arb
@@ -4,9 +4,9 @@
   "@appTitle": {
     "description": "Title for the app"
   },
-  "homeMessage": "Pantalla de inicio",
-  "@homeMessage": {
-    "description": "Message displayed on the home screen"
+  "ipaqName": "IPAQ",
+  "@ipaqName": {
+    "description": "IPAQ name displayed on the home screen"
   },
   "languageToolTip": "Seleccionar idioma",
   "@languageToolTip": {

--- a/packages/cht_ema_surveys/example/lib/l10n/generated/app_localizations.dart
+++ b/packages/cht_ema_surveys/example/lib/l10n/generated/app_localizations.dart
@@ -104,11 +104,11 @@ abstract class AppLocalizations {
   /// **'CHT Surveys Example'**
   String get appTitle;
 
-  /// Message displayed on the home screen
+  /// IPAQ name displayed on the home screen
   ///
   /// In en, this message translates to:
-  /// **'Home screen'**
-  String get homeMessage;
+  /// **'IPAQ'**
+  String get ipaqName;
 
   /// Tooltip for the language selection menu
   ///

--- a/packages/cht_ema_surveys/example/lib/l10n/generated/app_localizations_en.dart
+++ b/packages/cht_ema_surveys/example/lib/l10n/generated/app_localizations_en.dart
@@ -12,7 +12,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get appTitle => 'CHT Surveys Example';
 
   @override
-  String get homeMessage => 'Home screen';
+  String get ipaqName => 'IPAQ';
 
   @override
   String get languageToolTip => 'Select Language';

--- a/packages/cht_ema_surveys/example/lib/l10n/generated/app_localizations_es.dart
+++ b/packages/cht_ema_surveys/example/lib/l10n/generated/app_localizations_es.dart
@@ -12,7 +12,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get appTitle => 'Ejemplo CHT Encuestas';
 
   @override
-  String get homeMessage => 'Pantalla de inicio';
+  String get ipaqName => 'IPAQ';
 
   @override
   String get languageToolTip => 'Seleccionar idioma';

--- a/packages/cht_ema_surveys/example/lib/main.dart
+++ b/packages/cht_ema_surveys/example/lib/main.dart
@@ -110,22 +110,6 @@ class SurveyList extends StatelessWidget {
               ),
             ),
             const SizedBox(height: 24),
-            ElevatedButton(
-              onPressed: () => Navigator.push(
-                context,
-                MaterialPageRoute<void>(
-                  builder: (context) => ErqEmaPage(
-                    navigateOnFinish: (BuildContext context) {
-                      Navigator.of(context).pop();
-                    },
-                  ),
-                ),
-              ),
-              child: Text(
-                'ERQ EMA', // or a localized label if you add one to app_en/app_es
-                style: Theme.of(context).textTheme.headlineMedium,
-              ),
-            ),
           ],
         ),
       ),

--- a/packages/cht_ema_surveys/example/lib/main.dart
+++ b/packages/cht_ema_surveys/example/lib/main.dart
@@ -61,6 +61,7 @@ class _HomePageState extends State<HomePage> {
           PopupMenuButton<Locale?>(
             tooltip: localizations.languageToolTip,
             onSelected: widget.onLocaleChange,
+            icon: const Icon(Icons.language),
             itemBuilder: (BuildContext context) {
               return <PopupMenuItem<Locale?>>[
                 PopupMenuItem<Locale?>(
@@ -95,10 +96,33 @@ class SurveyList extends StatelessWidget {
             ElevatedButton(
               onPressed: () => Navigator.push(
                 context,
-                MaterialPageRoute<void>(builder: (context) => SurveyPage()),
+                MaterialPageRoute<void>(
+                  builder: (context) => IPAQPage(
+                    navigateOnFinish: (BuildContext context) {
+                      Navigator.of(context).pop();
+                    },
+                  ),
+                ),
               ),
               child: Text(
-                localizations.homeMessage,
+                localizations.ipaqName,
+                style: Theme.of(context).textTheme.headlineMedium,
+              ),
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: () => Navigator.push(
+                context,
+                MaterialPageRoute<void>(
+                  builder: (context) => ErqEmaPage(
+                    navigateOnFinish: (BuildContext context) {
+                      Navigator.of(context).pop();
+                    },
+                  ),
+                ),
+              ),
+              child: Text(
+                'ERQ EMA', // or a localized label if you add one to app_en/app_es
                 style: Theme.of(context).textTheme.headlineMedium,
               ),
             ),

--- a/packages/cht_ema_surveys/example/pubspec.yaml
+++ b/packages/cht_ema_surveys/example/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
+  iconify_flutter: ^0.0.7
   intl: any
   research_package:
     git:

--- a/packages/cht_ema_surveys/lib/cht_ema_surveys.dart
+++ b/packages/cht_ema_surveys/lib/cht_ema_surveys.dart
@@ -4,6 +4,8 @@ import 'package:research_package/ui.dart';
 
 export 'package:cht_ema_surveys/src/core/l10n/cht_rp_localization_loader.dart';
 export 'package:cht_ema_surveys/src/core/l10n/generated/cht_ema_surveys_localization.dart';
+export 'package:cht_ema_surveys/src/erq_ema/presentation/erq_ema_page.dart';
+export 'package:cht_ema_surveys/src/ipaq/presentation/ipaq_page.dart';
 
 class SurveyPage extends StatelessWidget {
   SurveyPage({super.key});

--- a/packages/cht_ema_surveys/lib/cht_ema_surveys.dart
+++ b/packages/cht_ema_surveys/lib/cht_ema_surveys.dart
@@ -4,7 +4,6 @@ import 'package:research_package/ui.dart';
 
 export 'package:cht_ema_surveys/src/core/l10n/cht_rp_localization_loader.dart';
 export 'package:cht_ema_surveys/src/core/l10n/generated/cht_ema_surveys_localization.dart';
-export 'package:cht_ema_surveys/src/erq_ema/presentation/erq_ema_page.dart';
 export 'package:cht_ema_surveys/src/ipaq/presentation/ipaq_page.dart';
 
 class SurveyPage extends StatelessWidget {

--- a/packages/cht_ema_surveys/lib/src/core/l10n/generated/cht_ema_surveys_localization.dart
+++ b/packages/cht_ema_surveys/lib/src/core/l10n/generated/cht_ema_surveys_localization.dart
@@ -106,6 +106,120 @@ abstract class ChtEmaSurveysLocalization {
   /// In en, this message translates to:
   /// **'Title for survey item'**
   String get itemTitle;
+
+  /// IPAQ intro step title
+  ///
+  /// In en, this message translates to:
+  /// **'Physical Activity'**
+  String get ipaqInstructionsTitle;
+
+  /// IPAQ introductory explanatory text
+  ///
+  /// In en, this message translates to:
+  /// **'Next, you will answer some questions about the kinds of physical activity you did today.\n\nPlease answer each question even if you do not think of yourself as a physically active person.\n\nPlease think about activities you do as part of your work, in the garden and at home, to get from one place to another, and in your free time for rest, exercise, or sports.'**
+  String get ipaqInstructionsBody;
+
+  /// IPAQ vigorous activity question
+  ///
+  /// In en, this message translates to:
+  /// **'How much time did you spend today doing vigorous physical activity?\n\nConsider it vigorous when you cannot say more than a few words without stopping to breathe, such as when jogging or swimming fast.'**
+  String get ipaqVigorousQuestionTitle;
+
+  /// IPAQ moderate activity question
+  ///
+  /// In en, this message translates to:
+  /// **'How much time did you spend today doing moderate physical activities, such as brisk walking, dancing, or cycling at an easy pace?'**
+  String get ipaqModerateQuestionTitle;
+
+  /// IPAQ walking question
+  ///
+  /// In en, this message translates to:
+  /// **'How much time did you spend today walking?'**
+  String get ipaqWalkQuestionTitle;
+
+  /// IPAQ sitting question
+  ///
+  /// In en, this message translates to:
+  /// **'How much time did you spend today sitting?'**
+  String get ipaqSeatedQuestionTitle;
+
+  /// Back button label in the survey
+  ///
+  /// In en, this message translates to:
+  /// **'Back'**
+  String get backButtonLabel;
+
+  /// Next/continue button label in the survey
+  ///
+  /// In en, this message translates to:
+  /// **'Continue'**
+  String get nextButtonLabel;
+
+  /// Prefix used before the question index
+  ///
+  /// In en, this message translates to:
+  /// **'Question'**
+  String get questionLabel;
+
+  /// Label for hours in duration picker
+  ///
+  /// In en, this message translates to:
+  /// **'Hours'**
+  String get hoursLabel;
+
+  /// Label for minutes in duration picker
+  ///
+  /// In en, this message translates to:
+  /// **'Minutes'**
+  String get minutesLabel;
+
+  /// Title for the ERQ EMA block
+  ///
+  /// In en, this message translates to:
+  /// **'Emotion Regulation'**
+  String get erqEmaInstructionsTitle;
+
+  /// Instructions for ERQ EMA items and 1–7 scale description
+  ///
+  /// In en, this message translates to:
+  /// **'Below are some statements about how you handled this emotion.\n\nPlease rate how much each statement describes what you did, using the following scale:\n1 = strongly disagree, 4 = neutral, 7 = strongly agree.'**
+  String get erqEmaInstructionsBody;
+
+  /// ERQ EMA cognitive reappraisal item 1
+  ///
+  /// In en, this message translates to:
+  /// **'I controlled this emotion by changing the way I was thinking about the situation I was in.'**
+  String get erqEmaCr1;
+
+  /// ERQ EMA cognitive reappraisal item 2
+  ///
+  /// In en, this message translates to:
+  /// **'When I wanted to feel less of this emotion, I changed what I was thinking about.'**
+  String get erqEmaCr2;
+
+  /// ERQ EMA cognitive reappraisal item 3
+  ///
+  /// In en, this message translates to:
+  /// **'When I wanted to feel less of this emotion, I changed the way I was thinking about the situation.'**
+  String get erqEmaCr3;
+
+  /// ERQ EMA expressive suppression item 1
+  ///
+  /// In en, this message translates to:
+  /// **'I controlled this emotion by not expressing it.'**
+  String get erqEmaSup1;
+
+  /// ERQ EMA expressive suppression item 2
+  ///
+  /// In en, this message translates to:
+  /// **'I kept this emotion to myself.'**
+  String get erqEmaSup2;
+
+  /// ERQ EMA expressive suppression item 3
+  ///
+  /// In en, this message translates to:
+  /// **'When I felt this emotion, I made sure not to express it.'**
+  String get erqEmaSup3;
 }
 
 class _ChtEmaSurveysLocalizationDelegate

--- a/packages/cht_ema_surveys/lib/src/core/l10n/generated/cht_ema_surveys_localization_en.dart
+++ b/packages/cht_ema_surveys/lib/src/core/l10n/generated/cht_ema_surveys_localization_en.dart
@@ -10,4 +10,71 @@ class ChtEmaSurveysLocalizationEn extends ChtEmaSurveysLocalization {
 
   @override
   String get itemTitle => 'Title for survey item';
+
+  @override
+  String get ipaqInstructionsTitle => 'Physical Activity';
+
+  @override
+  String get ipaqInstructionsBody =>
+      'Next, you will answer some questions about the kinds of physical activity you did today.\n\nPlease answer each question even if you do not think of yourself as a physically active person.\n\nPlease think about activities you do as part of your work, in the garden and at home, to get from one place to another, and in your free time for rest, exercise, or sports.';
+
+  @override
+  String get ipaqVigorousQuestionTitle =>
+      'How much time did you spend today doing vigorous physical activity?\n\nConsider it vigorous when you cannot say more than a few words without stopping to breathe, such as when jogging or swimming fast.';
+
+  @override
+  String get ipaqModerateQuestionTitle =>
+      'How much time did you spend today doing moderate physical activities, such as brisk walking, dancing, or cycling at an easy pace?';
+
+  @override
+  String get ipaqWalkQuestionTitle =>
+      'How much time did you spend today walking?';
+
+  @override
+  String get ipaqSeatedQuestionTitle =>
+      'How much time did you spend today sitting?';
+
+  @override
+  String get backButtonLabel => 'Back';
+
+  @override
+  String get nextButtonLabel => 'Continue';
+
+  @override
+  String get questionLabel => 'Question';
+
+  @override
+  String get hoursLabel => 'Hours';
+
+  @override
+  String get minutesLabel => 'Minutes';
+
+  @override
+  String get erqEmaInstructionsTitle => 'Emotion Regulation';
+
+  @override
+  String get erqEmaInstructionsBody =>
+      'Below are some statements about how you handled this emotion.\n\nPlease rate how much each statement describes what you did, using the following scale:\n1 = strongly disagree, 4 = neutral, 7 = strongly agree.';
+
+  @override
+  String get erqEmaCr1 =>
+      'I controlled this emotion by changing the way I was thinking about the situation I was in.';
+
+  @override
+  String get erqEmaCr2 =>
+      'When I wanted to feel less of this emotion, I changed what I was thinking about.';
+
+  @override
+  String get erqEmaCr3 =>
+      'When I wanted to feel less of this emotion, I changed the way I was thinking about the situation.';
+
+  @override
+  String get erqEmaSup1 => 'I controlled this emotion by not expressing it.';
+
+  @override
+  String get erqEmaSup2 => 'I kept this emotion to myself.';
+
+  @override
+  String get erqEmaSup3 =>
+      'When I felt this emotion, I made sure not to express it.';
 }

--- a/packages/cht_ema_surveys/lib/src/core/l10n/generated/cht_ema_surveys_localization_es.dart
+++ b/packages/cht_ema_surveys/lib/src/core/l10n/generated/cht_ema_surveys_localization_es.dart
@@ -9,5 +9,70 @@ class ChtEmaSurveysLocalizationEs extends ChtEmaSurveysLocalization {
   ChtEmaSurveysLocalizationEs([String locale = 'es']) : super(locale);
 
   @override
-  String get itemTitle => 'Título del item';
+  String get itemTitle => 'Título del ítem';
+
+  @override
+  String get ipaqInstructionsTitle => 'Actividad Física';
+
+  @override
+  String get ipaqInstructionsBody =>
+      'A continuación responderás algunas preguntas sobre la clase de actividad física que realizaste hoy.\n\nPor favor, responde a cada pregunta aun si no te consideras una persona activa.\n\nPor favor, piensa en aquellas actividades que haces como parte del trabajo, en el jardín y en la casa, para ir de un sitio a otro, y en tu tiempo libre de descanso, ejercicio o deporte.';
+
+  @override
+  String get ipaqVigorousQuestionTitle =>
+      '¿Cuánto tiempo dedicaste hoy a actividad física vigorosa?\n\nConsidera vigorosa cuando no puedes decir más de unas pocas palabras sin parar a respirar, como al trotar o nadar rápido.';
+
+  @override
+  String get ipaqModerateQuestionTitle =>
+      '¿Cuánto tiempo dedicaste hoy a realizar actividades físicas moderadas, como caminar rápido, bailar o andar en bicicleta a ritmo suave?';
+
+  @override
+  String get ipaqWalkQuestionTitle => '¿Cuánto tiempo dedicaste hoy a caminar?';
+
+  @override
+  String get ipaqSeatedQuestionTitle => '¿Cuánto tiempo estuviste hoy sentado?';
+
+  @override
+  String get backButtonLabel => 'Atrás';
+
+  @override
+  String get nextButtonLabel => 'Continuar';
+
+  @override
+  String get questionLabel => 'Pregunta';
+
+  @override
+  String get hoursLabel => 'Horas';
+
+  @override
+  String get minutesLabel => 'Minutos';
+
+  @override
+  String get erqEmaInstructionsTitle => 'Regulación emocional';
+
+  @override
+  String get erqEmaInstructionsBody =>
+      'A continuación verás algunas frases sobre cómo manejaste esta emoción.\n\nIndica qué tanto cada frase describe lo que hiciste, usando la siguiente escala:\n1 = muy en desacuerdo, 4 = ni de acuerdo ni en desacuerdo, 7 = muy de acuerdo.';
+
+  @override
+  String get erqEmaCr1 =>
+      'Controlé esta emoción cambiando la manera en que estaba pensando sobre la situación en la que me encontraba.';
+
+  @override
+  String get erqEmaCr2 =>
+      'Cuando quería sentir menos de esta emoción, cambié en qué estaba pensando.';
+
+  @override
+  String get erqEmaCr3 =>
+      'Cuando quería sentir menos de esta emoción, cambié la manera en que estaba pensando sobre la situación.';
+
+  @override
+  String get erqEmaSup1 => 'Controlé esta emoción al no expresarla.';
+
+  @override
+  String get erqEmaSup2 => 'Me guardé esta emoción para mí.';
+
+  @override
+  String get erqEmaSup3 =>
+      'Cuando sentí esta emoción, me aseguré de no expresarla.';
 }

--- a/packages/cht_ema_surveys/lib/src/core/l10n/package_en.arb
+++ b/packages/cht_ema_surveys/lib/src/core/l10n/package_en.arb
@@ -3,5 +3,86 @@
   "itemTitle": "Title for survey item",
   "@itemTitle": {
     "description": "Title for the EMA survey item"
+  },
+
+  "ipaqInstructionsTitle": "Physical Activity",
+  "@ipaqInstructionsTitle": {
+    "description": "IPAQ intro step title"
+  },
+  "ipaqInstructionsBody": "Next, you will answer some questions about the kinds of physical activity you did today.\n\nPlease answer each question even if you do not think of yourself as a physically active person.\n\nPlease think about activities you do as part of your work, in the garden and at home, to get from one place to another, and in your free time for rest, exercise, or sports.",
+  "@ipaqInstructionsBody": {
+    "description": "IPAQ introductory explanatory text"
+  },
+  "ipaqVigorousQuestionTitle": "How much time did you spend today doing vigorous physical activity?\n\nConsider it vigorous when you cannot say more than a few words without stopping to breathe, such as when jogging or swimming fast.",
+  "@ipaqVigorousQuestionTitle": {
+    "description": "IPAQ vigorous activity question"
+  },
+  "ipaqModerateQuestionTitle": "How much time did you spend today doing moderate physical activities, such as brisk walking, dancing, or cycling at an easy pace?",
+  "@ipaqModerateQuestionTitle": {
+    "description": "IPAQ moderate activity question"
+  },
+  "ipaqWalkQuestionTitle": "How much time did you spend today walking?",
+  "@ipaqWalkQuestionTitle": {
+    "description": "IPAQ walking question"
+  },
+  "ipaqSeatedQuestionTitle": "How much time did you spend today sitting?",
+  "@ipaqSeatedQuestionTitle": {
+    "description": "IPAQ sitting question"
+  },
+
+  "backButtonLabel": "Back",
+  "@backButtonLabel": {
+    "description": "Back button label in the survey"
+  },
+  "nextButtonLabel": "Continue",
+  "@nextButtonLabel": {
+    "description": "Next/continue button label in the survey"
+  },
+  "questionLabel": "Question",
+  "@questionLabel": {
+    "description": "Prefix used before the question index"
+  },
+  "hoursLabel": "Hours",
+  "@hoursLabel": {
+    "description": "Label for hours in duration picker"
+  },
+  "minutesLabel": "Minutes",
+  "@minutesLabel": {
+    "description": "Label for minutes in duration picker"
+  },
+
+  "erqEmaInstructionsTitle": "Emotion Regulation",
+  "@erqEmaInstructionsTitle": {
+    "description": "Title for the ERQ EMA block"
+  },
+  "erqEmaInstructionsBody": "Below are some statements about how you handled this emotion.\n\nPlease rate how much each statement describes what you did, using the following scale:\n1 = strongly disagree, 4 = neutral, 7 = strongly agree.",
+  "@erqEmaInstructionsBody": {
+    "description": "Instructions for ERQ EMA items and 1–7 scale description"
+  },
+
+  "erqEmaCr1": "I controlled this emotion by changing the way I was thinking about the situation I was in.",
+  "@erqEmaCr1": {
+    "description": "ERQ EMA cognitive reappraisal item 1"
+  },
+  "erqEmaCr2": "When I wanted to feel less of this emotion, I changed what I was thinking about.",
+  "@erqEmaCr2": {
+    "description": "ERQ EMA cognitive reappraisal item 2"
+  },
+  "erqEmaCr3": "When I wanted to feel less of this emotion, I changed the way I was thinking about the situation.",
+  "@erqEmaCr3": {
+    "description": "ERQ EMA cognitive reappraisal item 3"
+  },
+
+  "erqEmaSup1": "I controlled this emotion by not expressing it.",
+  "@erqEmaSup1": {
+    "description": "ERQ EMA expressive suppression item 1"
+  },
+  "erqEmaSup2": "I kept this emotion to myself.",
+  "@erqEmaSup2": {
+    "description": "ERQ EMA expressive suppression item 2"
+  },
+  "erqEmaSup3": "When I felt this emotion, I made sure not to express it.",
+  "@erqEmaSup3": {
+    "description": "ERQ EMA expressive suppression item 3"
   }
 }

--- a/packages/cht_ema_surveys/lib/src/core/l10n/package_es.arb
+++ b/packages/cht_ema_surveys/lib/src/core/l10n/package_es.arb
@@ -1,7 +1,88 @@
 {
   "@@locale": "es",
-  "itemTitle": "Título del item",
+  "itemTitle": "Título del ítem",
   "@itemTitle": {
-    "description": "Title for the EMA survey item"
+    "description": "Título para el ítem de la EMA"
+  },
+
+  "ipaqInstructionsTitle": "Actividad Física",
+  "@ipaqInstructionsTitle": {
+    "description": "Título de la pantalla de instrucciones del IPAQ"
+  },
+  "ipaqInstructionsBody": "A continuación responderás algunas preguntas sobre la clase de actividad física que realizaste hoy.\n\nPor favor, responde a cada pregunta aun si no te consideras una persona activa.\n\nPor favor, piensa en aquellas actividades que haces como parte del trabajo, en el jardín y en la casa, para ir de un sitio a otro, y en tu tiempo libre de descanso, ejercicio o deporte.",
+  "@ipaqInstructionsBody": {
+    "description": "Texto introductorio del IPAQ"
+  },
+  "ipaqVigorousQuestionTitle": "¿Cuánto tiempo dedicaste hoy a actividad física vigorosa?\n\nConsidera vigorosa cuando no puedes decir más de unas pocas palabras sin parar a respirar, como al trotar o nadar rápido.",
+  "@ipaqVigorousQuestionTitle": {
+    "description": "Pregunta sobre actividad física vigorosa"
+  },
+  "ipaqModerateQuestionTitle": "¿Cuánto tiempo dedicaste hoy a realizar actividades físicas moderadas, como caminar rápido, bailar o andar en bicicleta a ritmo suave?",
+  "@ipaqModerateQuestionTitle": {
+    "description": "Pregunta sobre actividad física moderada"
+  },
+  "ipaqWalkQuestionTitle": "¿Cuánto tiempo dedicaste hoy a caminar?",
+  "@ipaqWalkQuestionTitle": {
+    "description": "Pregunta sobre caminata"
+  },
+  "ipaqSeatedQuestionTitle": "¿Cuánto tiempo estuviste hoy sentado?",
+  "@ipaqSeatedQuestionTitle": {
+    "description": "Pregunta sobre tiempo sentado"
+  },
+
+  "backButtonLabel": "Atrás",
+  "@backButtonLabel": {
+    "description": "Etiqueta del botón Atrás en el cuestionario"
+  },
+  "nextButtonLabel": "Continuar",
+  "@nextButtonLabel": {
+    "description": "Etiqueta del botón Continuar en el cuestionario"
+  },
+  "questionLabel": "Pregunta",
+  "@questionLabel": {
+    "description": "Prefijo que se muestra antes del número de la pregunta"
+  },
+  "hoursLabel": "Horas",
+  "@hoursLabel": {
+    "description": "Etiqueta para horas en el selector de duración"
+  },
+  "minutesLabel": "Minutos",
+  "@minutesLabel": {
+    "description": "Etiqueta para minutos en el selector de duración"
+  },
+
+  "erqEmaInstructionsTitle": "Regulación emocional",
+  "@erqEmaInstructionsTitle": {
+    "description": "Título del bloque ERQ EMA"
+  },
+  "erqEmaInstructionsBody": "A continuación verás algunas frases sobre cómo manejaste esta emoción.\n\nIndica qué tanto cada frase describe lo que hiciste, usando la siguiente escala:\n1 = muy en desacuerdo, 4 = ni de acuerdo ni en desacuerdo, 7 = muy de acuerdo.",
+  "@erqEmaInstructionsBody": {
+    "description": "Instrucciones para los ítems de ERQ EMA y descripción de la escala 1–7"
+  },
+
+  "erqEmaCr1": "Controlé esta emoción cambiando la manera en que estaba pensando sobre la situación en la que me encontraba.",
+  "@erqEmaCr1": {
+    "description": "ERQ EMA, ítem de reevaluación cognitiva 1"
+  },
+  "erqEmaCr2": "Cuando quería sentir menos de esta emoción, cambié en qué estaba pensando.",
+  "@erqEmaCr2": {
+    "description": "ERQ EMA, ítem de reevaluación cognitiva 2"
+  },
+  "erqEmaCr3": "Cuando quería sentir menos de esta emoción, cambié la manera en que estaba pensando sobre la situación.",
+  "@erqEmaCr3": {
+    "description": "ERQ EMA, ítem de reevaluación cognitiva 3"
+  },
+
+  "erqEmaSup1": "Controlé esta emoción al no expresarla.",
+  "@erqEmaSup1": {
+    "description": "ERQ EMA, ítem de supresión expresiva 1"
+  },
+  "erqEmaSup2": "Me guardé esta emoción para mí.",
+  "@erqEmaSup2": {
+    "description": "ERQ EMA, ítem de supresión expresiva 2"
+  },
+  "erqEmaSup3": "Cuando sentí esta emoción, me aseguré de no expresarla.",
+  "@erqEmaSup3": {
+    "description": "ERQ EMA, ítem de supresión expresiva 3"
   }
 }

--- a/packages/cht_ema_surveys/lib/src/ipaq/data/custom_answer_result.dart
+++ b/packages/cht_ema_surveys/lib/src/ipaq/data/custom_answer_result.dart
@@ -1,0 +1,10 @@
+import 'package:research_package/model.dart';
+
+class CustomAnswerResult extends RPResult {
+  final dynamic answer;
+
+  CustomAnswerResult({
+    required super.identifier,
+    this.answer,
+  });
+}

--- a/packages/cht_ema_surveys/lib/src/ipaq/data/items.dart
+++ b/packages/cht_ema_surveys/lib/src/ipaq/data/items.dart
@@ -1,5 +1,4 @@
 import 'package:cht_ema_surveys/src/core/l10n/generated/cht_ema_surveys_localization.dart';
-import 'package:cht_ema_surveys/src/ipaq/presentation/widgets/duration_answer_format.dart';
 import 'package:flutter/material.dart';
 import 'package:iconify_flutter/icons/mdi.dart';
 import 'package:research_package/research_package.dart';

--- a/packages/cht_ema_surveys/lib/src/ipaq/data/items.dart
+++ b/packages/cht_ema_surveys/lib/src/ipaq/data/items.dart
@@ -1,0 +1,74 @@
+import 'package:cht_ema_surveys/src/core/l10n/generated/cht_ema_surveys_localization.dart';
+import 'package:cht_ema_surveys/src/ipaq/presentation/widgets/duration_answer_format.dart';
+import 'package:flutter/material.dart';
+import 'package:iconify_flutter/icons/mdi.dart';
+import 'package:research_package/research_package.dart';
+
+/// Builds the list of IPAQ steps using localized strings.
+List<RPStep> buildIpaqSteps(BuildContext context) {
+  final l10n = ChtEmaSurveysLocalization.of(context);
+
+  final ipaq1 = RPQuestionStep(
+    identifier: 'ipaq_vigorous',
+    title: l10n.ipaqVigorousQuestionTitle,
+    answerFormat: DurationAnswerFormat(),
+  );
+
+  final ipaq2 = RPQuestionStep(
+    identifier: 'ipaq_moderate',
+    title: l10n.ipaqModerateQuestionTitle,
+    answerFormat: DurationAnswerFormat(),
+  );
+
+  final ipaq3 = RPQuestionStep(
+    identifier: 'ipaq_walk',
+    title: l10n.ipaqWalkQuestionTitle,
+    answerFormat: DurationAnswerFormat(),
+  );
+
+  final ipaq4 = RPQuestionStep(
+    identifier: 'ipaq_seated',
+    title: l10n.ipaqSeatedQuestionTitle,
+    answerFormat: DurationAnswerFormat(),
+  );
+
+  return <RPStep>[
+    RPInstructionStep(
+      identifier: 'ipaq_instructions',
+      title: l10n.ipaqInstructionsTitle,
+      detailText: l10n.ipaqInstructionsBody,
+    ),
+    ipaq1,
+    ipaq2,
+    ipaq3,
+    ipaq4,
+  ];
+}
+
+final Map<String, String> questionIcons = {
+  'ipaq_vigorous': Mdi.run_fast,
+  'ipaq_moderate': Mdi.run,
+  'ipaq_walk': Mdi.walk,
+  'ipaq_seated': Mdi.seat_recline_normal,
+};
+
+final Map<String, List<String>> questionIconsTriple = {
+  'ipaq_vigorous': [
+    Mdi.run_fast,
+    Mdi.weight_lifter,
+    Mdi.basketball_hoop,
+    Mdi.bike_fast,
+  ],
+  'ipaq_moderate': [
+    Mdi.run,
+    Mdi.bicycle,
+    Mdi.swim,
+  ],
+};
+
+final Map<String, Color> questionIconColors = {
+  'ipaq_vigorous': Colors.red,
+  'ipaq_moderate': Colors.orange,
+  'ipaq_walk': Colors.green,
+  'ipaq_seated': Colors.purple,
+};

--- a/packages/cht_ema_surveys/lib/src/ipaq/data/items.dart
+++ b/packages/cht_ema_surveys/lib/src/ipaq/data/items.dart
@@ -1,4 +1,5 @@
 import 'package:cht_ema_surveys/src/core/l10n/generated/cht_ema_surveys_localization.dart';
+import 'package:cht_ema_surveys/src/ipaq/presentation/widgets/duration_answer_format.dart';
 import 'package:flutter/material.dart';
 import 'package:iconify_flutter/icons/mdi.dart';
 import 'package:research_package/research_package.dart';

--- a/packages/cht_ema_surveys/lib/src/ipaq/presentation/ipaq_page.dart
+++ b/packages/cht_ema_surveys/lib/src/ipaq/presentation/ipaq_page.dart
@@ -1,0 +1,26 @@
+import 'package:cht_ema_surveys/src/ipaq/presentation/ipaq_viewmodel.dart';
+import 'package:cht_ema_surveys/src/ipaq/presentation/widgets/custom_task_widget.dart';
+import 'package:flutter/material.dart';
+
+class IPAQPage extends StatelessWidget {
+  final IPAQViewModel viewModel = IPAQViewModel();
+  final void Function(BuildContext context) navigateOnFinish;
+
+  IPAQPage({
+    required this.navigateOnFinish,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomTaskWidget(
+      task: viewModel.buildTask(context),
+      onSubmit: (result) async {
+        viewModel.saveData(result);
+        await viewModel.closeIpaqPage();
+        //use_build_context_synchronously
+        //navigateOnFinish(context);
+      },
+    );
+  }
+}

--- a/packages/cht_ema_surveys/lib/src/ipaq/presentation/ipaq_page.dart
+++ b/packages/cht_ema_surveys/lib/src/ipaq/presentation/ipaq_page.dart
@@ -18,8 +18,9 @@ class IPAQPage extends StatelessWidget {
       onSubmit: (result) async {
         viewModel.saveData(result);
         await viewModel.closeIpaqPage();
-        //use_build_context_synchronously
-        //navigateOnFinish(context);
+        // Context is valid here since closeIpaqPage has no async gap that outlives it.
+        // ignore: use_build_context_synchronously
+        navigateOnFinish(context);
       },
     );
   }

--- a/packages/cht_ema_surveys/lib/src/ipaq/presentation/ipaq_page.dart
+++ b/packages/cht_ema_surveys/lib/src/ipaq/presentation/ipaq_page.dart
@@ -18,8 +18,8 @@ class IPAQPage extends StatelessWidget {
       onSubmit: (result) async {
         viewModel.saveData(result);
         await viewModel.closeIpaqPage();
-        // Context is valid here since closeIpaqPage has no async gap that outlives it.
-        // ignore: use_build_context_synchronously
+        if (!context.mounted) return;
+
         navigateOnFinish(context);
       },
     );

--- a/packages/cht_ema_surveys/lib/src/ipaq/presentation/ipaq_viewmodel.dart
+++ b/packages/cht_ema_surveys/lib/src/ipaq/presentation/ipaq_viewmodel.dart
@@ -1,0 +1,15 @@
+import 'package:cht_ema_surveys/src/ipaq/data/items.dart';
+import 'package:flutter/material.dart';
+import 'package:research_package/model.dart';
+
+class IPAQViewModel {
+  RPOrderedTask buildTask(BuildContext context) => RPOrderedTask(
+    identifier: 'ipaq_task',
+    steps: buildIpaqSteps(context),
+    closeAfterFinished: false,
+  );
+
+  Future<void> closeIpaqPage() async {}
+
+  void saveData(RPTaskResult results) {}
+}

--- a/packages/cht_ema_surveys/lib/src/ipaq/presentation/widgets/custom_duration_picker.dart
+++ b/packages/cht_ema_surveys/lib/src/ipaq/presentation/widgets/custom_duration_picker.dart
@@ -28,11 +28,19 @@ class _CustomDurationPickerState extends State<CustomDurationPicker> {
   late FixedExtentScrollController _hoursController;
   late FixedExtentScrollController _minutesController;
 
+  int _effectiveMax(int max) => max < 0 ? 0 : max;
+
   @override
   void initState() {
     super.initState();
-    selectedHours = widget.initialDuration.inHours;
-    selectedMinutes = widget.initialDuration.inMinutes % 60;
+    final maxHours = _effectiveMax(widget.maxHours);
+    final maxMinutes = _effectiveMax(widget.maxMinutes);
+
+    selectedHours = widget.initialDuration.inHours.clamp(0, maxHours);
+    selectedMinutes = (widget.initialDuration.inMinutes % 60).clamp(
+      0,
+      maxMinutes,
+    );
 
     _hoursController = FixedExtentScrollController(initialItem: selectedHours);
     _minutesController = FixedExtentScrollController(
@@ -68,7 +76,7 @@ class _CustomDurationPickerState extends State<CustomDurationPicker> {
           _buildPicker(
             label: l10n.hoursLabel,
             value: selectedHours,
-            max: widget.maxHours,
+            max: _effectiveMax(widget.maxHours),
             controller: _hoursController,
             onChanged: (index) async {
               setState(() => selectedHours = index);
@@ -86,7 +94,7 @@ class _CustomDurationPickerState extends State<CustomDurationPicker> {
           _buildPicker(
             label: l10n.minutesLabel,
             value: selectedMinutes,
-            max: widget.maxMinutes,
+            max: _effectiveMax(widget.maxMinutes),
             controller: _minutesController,
             onChanged: (index) async {
               setState(() => selectedMinutes = index);

--- a/packages/cht_ema_surveys/lib/src/ipaq/presentation/widgets/custom_duration_picker.dart
+++ b/packages/cht_ema_surveys/lib/src/ipaq/presentation/widgets/custom_duration_picker.dart
@@ -1,0 +1,143 @@
+import 'package:cht_ema_surveys/src/core/l10n/generated/cht_ema_surveys_localization.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+class CustomDurationPicker extends StatefulWidget {
+  final Duration initialDuration;
+  final ValueChanged<Duration> onDurationChanged;
+  final int maxHours;
+  final int maxMinutes;
+
+  const CustomDurationPicker({
+    required this.initialDuration,
+    required this.onDurationChanged,
+    super.key,
+    this.maxHours = 23,
+    this.maxMinutes = 59,
+  });
+
+  @override
+  State<CustomDurationPicker> createState() => _CustomDurationPickerState();
+}
+
+class _CustomDurationPickerState extends State<CustomDurationPicker> {
+  late int selectedHours;
+  late int selectedMinutes;
+
+  late FixedExtentScrollController _hoursController;
+  late FixedExtentScrollController _minutesController;
+
+  @override
+  void initState() {
+    super.initState();
+    selectedHours = widget.initialDuration.inHours;
+    selectedMinutes = widget.initialDuration.inMinutes % 60;
+
+    _hoursController = FixedExtentScrollController(initialItem: selectedHours);
+    _minutesController = FixedExtentScrollController(
+      initialItem: selectedMinutes,
+    );
+  }
+
+  @override
+  void dispose() {
+    _hoursController.dispose();
+    _minutesController.dispose();
+    super.dispose();
+  }
+
+  void _updateDuration() {
+    final duration = Duration(hours: selectedHours, minutes: selectedMinutes);
+    widget.onDurationChanged(duration);
+  }
+
+  Future<void> _feedback() async {
+    await SystemSound.play(SystemSoundType.click);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = ChtEmaSurveysLocalization.of(context);
+
+    return SizedBox(
+      height: 200,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          _buildPicker(
+            label: l10n.hoursLabel,
+            value: selectedHours,
+            max: widget.maxHours,
+            controller: _hoursController,
+            onChanged: (index) async {
+              setState(() => selectedHours = index);
+              _updateDuration();
+              await _feedback();
+            },
+          ),
+          const Padding(
+            padding: EdgeInsets.symmetric(horizontal: 8),
+            child: Text(
+              ':',
+              style: TextStyle(fontSize: 35, fontWeight: FontWeight.w600),
+            ),
+          ),
+          _buildPicker(
+            label: l10n.minutesLabel,
+            value: selectedMinutes,
+            max: widget.maxMinutes,
+            controller: _minutesController,
+            onChanged: (index) async {
+              setState(() => selectedMinutes = index);
+              _updateDuration();
+              await _feedback();
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPicker({
+    required String label,
+    required int value,
+    required int max,
+    required FixedExtentScrollController controller,
+    required ValueChanged<int> onChanged,
+  }) {
+    return Expanded(
+      child: Column(
+        children: [
+          Text(
+            label,
+            style: const TextStyle(
+              fontSize: 35,
+              color: Colors.black,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Expanded(
+            child: CupertinoPicker(
+              scrollController: controller,
+              itemExtent: 45,
+              useMagnifier: true,
+              magnification: 1.05,
+              onSelectedItemChanged: onChanged,
+              children: List<Widget>.generate(
+                max + 1,
+                (index) => Center(
+                  child: Text(
+                    index.toString().padLeft(2, '0'),
+                    style: const TextStyle(fontSize: 35),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/cht_ema_surveys/lib/src/ipaq/presentation/widgets/custom_duration_question_body.dart
+++ b/packages/cht_ema_surveys/lib/src/ipaq/presentation/widgets/custom_duration_question_body.dart
@@ -2,12 +2,12 @@ import 'package:cht_ema_surveys/src/ipaq/presentation/widgets/custom_duration_pi
 import 'package:cht_ema_surveys/src/ipaq/presentation/widgets/duration_answer_format.dart';
 import 'package:flutter/material.dart';
 
-class CustomRPUIDateTimeQuestionBody extends StatefulWidget {
+class CustomDurationQuestionBody extends StatefulWidget {
   final DurationAnswerFormat answerFormat;
   final void Function(Duration) onResultChange;
   final Duration? initialDuration;
 
-  const CustomRPUIDateTimeQuestionBody({
+  const CustomDurationQuestionBody({
     required this.answerFormat,
     required this.onResultChange,
     this.initialDuration,
@@ -15,12 +15,12 @@ class CustomRPUIDateTimeQuestionBody extends StatefulWidget {
   });
 
   @override
-  State<CustomRPUIDateTimeQuestionBody> createState() =>
-      _CustomRPUIDateTimeQuestionBodyState();
+  State<CustomDurationQuestionBody> createState() =>
+      _CustomDurationQuestionBodyState();
 }
 
-class _CustomRPUIDateTimeQuestionBodyState
-    extends State<CustomRPUIDateTimeQuestionBody> {
+class _CustomDurationQuestionBodyState
+    extends State<CustomDurationQuestionBody> {
   late Duration _duration;
 
   @override

--- a/packages/cht_ema_surveys/lib/src/ipaq/presentation/widgets/custom_duration_question_body.dart
+++ b/packages/cht_ema_surveys/lib/src/ipaq/presentation/widgets/custom_duration_question_body.dart
@@ -1,0 +1,47 @@
+import 'package:cht_ema_surveys/src/ipaq/presentation/widgets/custom_duration_picker.dart';
+import 'package:cht_ema_surveys/src/ipaq/presentation/widgets/duration_answer_format.dart';
+import 'package:flutter/material.dart';
+
+class CustomRPUIDateTimeQuestionBody extends StatefulWidget {
+  final DurationAnswerFormat answerFormat;
+  final void Function(Duration) onResultChange;
+  final Duration? initialDuration;
+
+  const CustomRPUIDateTimeQuestionBody({
+    required this.answerFormat,
+    required this.onResultChange,
+    this.initialDuration,
+    super.key,
+  });
+
+  @override
+  State<CustomRPUIDateTimeQuestionBody> createState() =>
+      _CustomRPUIDateTimeQuestionBodyState();
+}
+
+class _CustomRPUIDateTimeQuestionBodyState
+    extends State<CustomRPUIDateTimeQuestionBody> {
+  late Duration _duration;
+
+  @override
+  void initState() {
+    super.initState();
+    _duration = widget.initialDuration ?? Duration.zero;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 24),
+      child: CustomDurationPicker(
+        initialDuration: _duration,
+        maxHours: widget.answerFormat.maxHours,
+        maxMinutes: widget.answerFormat.maxMinutes,
+        onDurationChanged: (newDuration) {
+          setState(() => _duration = newDuration);
+          widget.onResultChange(newDuration);
+        },
+      ),
+    );
+  }
+}

--- a/packages/cht_ema_surveys/lib/src/ipaq/presentation/widgets/custom_task_widget.dart
+++ b/packages/cht_ema_surveys/lib/src/ipaq/presentation/widgets/custom_task_widget.dart
@@ -1,0 +1,324 @@
+import 'package:cht_ema_surveys/src/ipaq/data/custom_answer_result.dart';
+import 'package:cht_ema_surveys/src/ipaq/data/items.dart';
+import 'package:cht_ema_surveys/src/ipaq/presentation/widgets/custom_duration_question_body.dart';
+import 'package:cht_ema_surveys/src/ipaq/presentation/widgets/duration_answer_format.dart';
+import 'package:cht_ema_surveys/src/ipaq/presentation/widgets/wheel_answer_format.dart'
+    as wheel_widgets;
+import 'package:cht_ema_surveys/src/ipaq/presentation/widgets/wheel_answer_format.dart';
+import 'package:flutter/material.dart';
+import 'package:iconify_flutter/iconify_flutter.dart';
+import 'package:iconify_flutter/icons/mdi.dart';
+import 'package:research_package/model.dart';
+
+class CustomTaskWidget extends StatefulWidget {
+  final RPOrderedTask task;
+  final void Function(RPTaskResult) onSubmit;
+
+  const CustomTaskWidget({
+    required this.task,
+    required this.onSubmit,
+    super.key,
+  });
+
+  @override
+  State<CustomTaskWidget> createState() => _CustomTaskWidgetState();
+}
+
+class _CustomTaskWidgetState extends State<CustomTaskWidget> {
+  int _currentStepIndex = 0;
+
+  final RPTaskResult _taskResult = RPTaskResult(identifier: 'custom_task');
+
+  /// Local cache of answers per step identifier so that navigating
+  /// backwards can restore the previously selected value.
+  final Map<String, dynamic> _answers = <String, dynamic>{};
+
+  dynamic _currentAnswer;
+
+  void _nextStep() {
+    final currentStep = widget.task.steps[_currentStepIndex];
+
+    // Cache the current answer for back navigation.
+    if (_currentAnswer != null) {
+      _answers[currentStep.identifier] = _currentAnswer;
+    } else {
+      _answers.remove(currentStep.identifier);
+    }
+
+    final stepResult = CustomAnswerResult(
+      identifier: currentStep.identifier,
+      answer: _currentAnswer,
+    );
+    _taskResult.setStepResultForIdentifier(
+      currentStep.identifier,
+      stepResult,
+    );
+
+    if (_currentStepIndex + 1 >= widget.task.steps.length) {
+      // Last step: submit the entire task result.
+      widget.onSubmit(_taskResult);
+    } else {
+      setState(() {
+        // Move to next step and clear current answer so the new
+        // question starts in a "fresh" state.
+        _currentStepIndex++;
+        _currentAnswer = null;
+      });
+    }
+  }
+
+  void _previousStep() {
+    if (_currentStepIndex > 0) {
+      setState(() {
+        _currentStepIndex--;
+
+        final prevStep = widget.task.steps[_currentStepIndex];
+        // Restore the previously given answer for this step, if any.
+        _currentAnswer = _answers[prevStep.identifier];
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final step = widget.task.steps[_currentStepIndex];
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          step is RPInstructionStep
+              ? step.title
+              : 'Pregunta $_currentStepIndex',
+          style: const TextStyle(fontSize: 35, fontWeight: FontWeight.w600),
+          textAlign: TextAlign.center,
+        ),
+        backgroundColor: const Color.fromARGB(255, 217, 217, 217),
+      ),
+
+      // Only the content scrolls; buttons are pinned to the bottom.
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              if (step is RPInstructionStep) ...[
+                Text(
+                  step.detailText ?? '',
+                  style: const TextStyle(fontSize: 25),
+                  textAlign: TextAlign.left,
+                ),
+              ] else if (step is RPQuestionStep &&
+                  step.answerFormat is DurationAnswerFormat) ...[
+                _QuestionTitleWithIcon(
+                  title: step.title,
+                  identifier: step.identifier,
+                ),
+                CustomRPUIDateTimeQuestionBody(
+                  key: ValueKey(step.identifier),
+                  answerFormat: step.answerFormat as DurationAnswerFormat,
+                  // When navigating back, restore the previous duration.
+                  initialDuration: _currentAnswer is Duration
+                      ? _currentAnswer as Duration
+                      : _answers[step.identifier] is Duration
+                      ? _answers[step.identifier] as Duration
+                      : null,
+                  onResultChange: (val) {
+                    setState(() => _currentAnswer = val);
+                  },
+                ),
+              ] else if (step is RPQuestionStep &&
+                  step.answerFormat is WheelAnswerFormat) ...[
+                _QuestionTitleWithIcon(
+                  title: step.title,
+                  identifier: step.identifier,
+                ),
+                wheel_widgets.WheelQuestionBody(
+                  key: ValueKey(step.identifier),
+                  answerFormat:
+                      step.answerFormat as wheel_widgets.WheelAnswerFormat,
+                  // Restore previously selected value when going back.
+                  initialValue: _currentAnswer is int
+                      ? _currentAnswer as int
+                      : _answers[step.identifier] is int
+                      ? _answers[step.identifier] as int
+                      : null,
+                  onResultChange: (val) {
+                    setState(() {
+                      _currentAnswer = val;
+                    });
+                  },
+                ),
+              ],
+              const SizedBox(height: 24),
+            ],
+          ),
+        ),
+      ),
+
+      // Buttons anchored at the bottom, outside the scroll.
+      bottomNavigationBar: SafeArea(
+        top: false,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(24, 8, 24, 24),
+          child: Row(
+            children: [
+              Expanded(
+                child: ElevatedButton(
+                  onPressed: _currentStepIndex > 0 ? _previousStep : null,
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: const Color.fromARGB(255, 255, 115, 115),
+                    foregroundColor: Colors.black,
+                    minimumSize: const Size.fromHeight(50),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(30),
+                    ),
+                  ),
+                  child: const Text(
+                    'Atrás',
+                    style: TextStyle(fontSize: 25, fontWeight: FontWeight.w600),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 16),
+              Expanded(
+                child: ElevatedButton(
+                  onPressed:
+                      (step is RPInstructionStep || _currentAnswer != null)
+                      ? _nextStep
+                      : null,
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: const Color.fromARGB(255, 163, 255, 115),
+                    foregroundColor: Colors.black,
+                    minimumSize: const Size.fromHeight(50),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(30),
+                    ),
+                  ),
+                  child: const Text(
+                    'Continuar',
+                    style: TextStyle(fontSize: 25, fontWeight: FontWeight.w600),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _QuestionTitleWithIcon extends StatelessWidget {
+  final String title;
+  final String identifier;
+
+  const _QuestionTitleWithIcon({
+    required this.title,
+    required this.identifier,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    // If this identifier has a triple icon entry, use it; otherwise single.
+    final triple = questionIconsTriple[identifier];
+
+    final single = questionIcons[identifier] ?? Mdi.help_circle;
+    final color = questionIconColors[identifier] ?? Colors.blueAccent;
+
+    return Column(
+      children: [
+        if (triple != null && triple.isNotEmpty)
+          _TripleIconHeader(icons: triple, color: color)
+        else
+          _SingleIconHeader(iconName: single, color: color),
+        const SizedBox(height: 16),
+        Text(
+          title,
+          textAlign: TextAlign.center,
+          style: const TextStyle(
+            fontSize: 28,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        const SizedBox(height: 16),
+      ],
+    );
+  }
+}
+
+class _SingleIconHeader extends StatelessWidget {
+  final String iconName;
+  final Color color;
+
+  const _SingleIconHeader({
+    required this.iconName,
+    required this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 76,
+      height: 76,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        color: color.withValues(alpha: 0.15),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.08),
+            blurRadius: 10,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Center(
+        child: Iconify(iconName, size: 46, color: color),
+      ),
+    );
+  }
+}
+
+class _TripleIconHeader extends StatelessWidget {
+  final List<String> icons;
+  final Color color;
+
+  const _TripleIconHeader({
+    required this.icons,
+    required this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final display = icons.take(4).toList();
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: display
+          .map(
+            (name) => Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8),
+              child: Container(
+                width: 56,
+                height: 56,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: color.withValues(alpha: 0.12),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black.withValues(alpha: 0.08),
+                      blurRadius: 10,
+                      offset: const Offset(0, 4),
+                    ),
+                  ],
+                ),
+                child: Center(
+                  child: Iconify(name, size: 36, color: color),
+                ),
+              ),
+            ),
+          )
+          .toList(),
+    );
+  }
+}

--- a/packages/cht_ema_surveys/lib/src/ipaq/presentation/widgets/custom_task_widget.dart
+++ b/packages/cht_ema_surveys/lib/src/ipaq/presentation/widgets/custom_task_widget.dart
@@ -1,3 +1,4 @@
+import 'package:cht_ema_surveys/src/core/l10n/generated/cht_ema_surveys_localization.dart';
 import 'package:cht_ema_surveys/src/ipaq/data/custom_answer_result.dart';
 import 'package:cht_ema_surveys/src/ipaq/data/items.dart';
 import 'package:cht_ema_surveys/src/ipaq/presentation/widgets/custom_duration_question_body.dart';
@@ -81,6 +82,7 @@ class _CustomTaskWidgetState extends State<CustomTaskWidget> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = ChtEmaSurveysLocalization.of(context);
     final step = widget.task.steps[_currentStepIndex];
 
     return Scaffold(
@@ -174,9 +176,9 @@ class _CustomTaskWidgetState extends State<CustomTaskWidget> {
                       borderRadius: BorderRadius.circular(30),
                     ),
                   ),
-                  child: const Text(
-                    'Atrás',
-                    style: TextStyle(fontSize: 25, fontWeight: FontWeight.w600),
+                  child: Text(
+                    l10n.backButtonLabel,
+                    style: const TextStyle(fontSize: 25, fontWeight: FontWeight.w600),
                   ),
                 ),
               ),
@@ -195,9 +197,9 @@ class _CustomTaskWidgetState extends State<CustomTaskWidget> {
                       borderRadius: BorderRadius.circular(30),
                     ),
                   ),
-                  child: const Text(
-                    'Continuar',
-                    style: TextStyle(fontSize: 25, fontWeight: FontWeight.w600),
+                  child: Text(
+                    l10n.nextButtonLabel,
+                    style: const TextStyle(fontSize: 25, fontWeight: FontWeight.w600),
                   ),
                 ),
               ),

--- a/packages/cht_ema_surveys/lib/src/ipaq/presentation/widgets/custom_task_widget.dart
+++ b/packages/cht_ema_surveys/lib/src/ipaq/presentation/widgets/custom_task_widget.dart
@@ -90,7 +90,7 @@ class _CustomTaskWidgetState extends State<CustomTaskWidget> {
         title: Text(
           step is RPInstructionStep
               ? step.title
-              : 'Pregunta $_currentStepIndex',
+              : '${l10n.questionLabel} $_currentStepIndex',
           style: const TextStyle(fontSize: 35, fontWeight: FontWeight.w600),
           textAlign: TextAlign.center,
         ),
@@ -178,7 +178,10 @@ class _CustomTaskWidgetState extends State<CustomTaskWidget> {
                   ),
                   child: Text(
                     l10n.backButtonLabel,
-                    style: const TextStyle(fontSize: 25, fontWeight: FontWeight.w600),
+                    style: const TextStyle(
+                      fontSize: 25,
+                      fontWeight: FontWeight.w600,
+                    ),
                   ),
                 ),
               ),
@@ -199,7 +202,10 @@ class _CustomTaskWidgetState extends State<CustomTaskWidget> {
                   ),
                   child: Text(
                     l10n.nextButtonLabel,
-                    style: const TextStyle(fontSize: 25, fontWeight: FontWeight.w600),
+                    style: const TextStyle(
+                      fontSize: 25,
+                      fontWeight: FontWeight.w600,
+                    ),
                   ),
                 ),
               ),

--- a/packages/cht_ema_surveys/lib/src/ipaq/presentation/widgets/custom_task_widget.dart
+++ b/packages/cht_ema_surveys/lib/src/ipaq/presentation/widgets/custom_task_widget.dart
@@ -5,7 +5,6 @@ import 'package:cht_ema_surveys/src/ipaq/presentation/widgets/custom_duration_qu
 import 'package:cht_ema_surveys/src/ipaq/presentation/widgets/duration_answer_format.dart';
 import 'package:cht_ema_surveys/src/ipaq/presentation/widgets/wheel_answer_format.dart'
     as wheel_widgets;
-import 'package:cht_ema_surveys/src/ipaq/presentation/widgets/wheel_answer_format.dart';
 import 'package:flutter/material.dart';
 import 'package:iconify_flutter/iconify_flutter.dart';
 import 'package:iconify_flutter/icons/mdi.dart';
@@ -36,10 +35,35 @@ class _CustomTaskWidgetState extends State<CustomTaskWidget> {
 
   dynamic _currentAnswer;
 
-  void _nextStep() {
+  @override
+  void initState() {
+    super.initState();
+    _currentAnswer = _answerForStep(widget.task.steps[_currentStepIndex]);
+  }
+
+  dynamic _defaultAnswerForStep(RPStep step) {
+    if (step is! RPQuestionStep) return null;
+
+    final answerFormat = step.answerFormat;
+    if (answerFormat is DurationAnswerFormat) {
+      return Duration.zero;
+    }
+
+    if (answerFormat is wheel_widgets.WheelAnswerFormat &&
+        answerFormat.choices.isNotEmpty) {
+      return answerFormat.choices.first;
+    }
+
+    return null;
+  }
+
+  dynamic _answerForStep(RPStep step) {
+    return _answers[step.identifier] ?? _defaultAnswerForStep(step);
+  }
+
+  void _saveCurrentStepAnswer() {
     final currentStep = widget.task.steps[_currentStepIndex];
 
-    // Cache the current answer for back navigation.
     if (_currentAnswer != null) {
       _answers[currentStep.identifier] = _currentAnswer;
     } else {
@@ -54,28 +78,39 @@ class _CustomTaskWidgetState extends State<CustomTaskWidget> {
       currentStep.identifier,
       stepResult,
     );
+  }
+
+  void _moveToStep(int stepIndex) {
+    _currentStepIndex = stepIndex;
+    _currentAnswer = _answerForStep(widget.task.steps[_currentStepIndex]);
+  }
+
+  int get _currentQuestionNumber {
+    return widget.task.steps
+        .take(_currentStepIndex + 1)
+        .whereType<RPQuestionStep>()
+        .length;
+  }
+
+  void _nextStep() {
+    _saveCurrentStepAnswer();
 
     if (_currentStepIndex + 1 >= widget.task.steps.length) {
       // Last step: submit the entire task result.
       widget.onSubmit(_taskResult);
     } else {
       setState(() {
-        // Move to next step and clear current answer so the new
-        // question starts in a "fresh" state.
-        _currentStepIndex++;
-        _currentAnswer = null;
+        _moveToStep(_currentStepIndex + 1);
       });
     }
   }
 
   void _previousStep() {
     if (_currentStepIndex > 0) {
-      setState(() {
-        _currentStepIndex--;
+      _saveCurrentStepAnswer();
 
-        final prevStep = widget.task.steps[_currentStepIndex];
-        // Restore the previously given answer for this step, if any.
-        _currentAnswer = _answers[prevStep.identifier];
+      setState(() {
+        _moveToStep(_currentStepIndex - 1);
       });
     }
   }
@@ -90,7 +125,7 @@ class _CustomTaskWidgetState extends State<CustomTaskWidget> {
         title: Text(
           step is RPInstructionStep
               ? step.title
-              : '${l10n.questionLabel} $_currentStepIndex',
+              : '${l10n.questionLabel} $_currentQuestionNumber',
           style: const TextStyle(fontSize: 35, fontWeight: FontWeight.w600),
           textAlign: TextAlign.center,
         ),
@@ -116,7 +151,7 @@ class _CustomTaskWidgetState extends State<CustomTaskWidget> {
                   title: step.title,
                   identifier: step.identifier,
                 ),
-                CustomRPUIDateTimeQuestionBody(
+                CustomDurationQuestionBody(
                   key: ValueKey(step.identifier),
                   answerFormat: step.answerFormat as DurationAnswerFormat,
                   // When navigating back, restore the previous duration.
@@ -130,7 +165,7 @@ class _CustomTaskWidgetState extends State<CustomTaskWidget> {
                   },
                 ),
               ] else if (step is RPQuestionStep &&
-                  step.answerFormat is WheelAnswerFormat) ...[
+                  step.answerFormat is wheel_widgets.WheelAnswerFormat) ...[
                 _QuestionTitleWithIcon(
                   title: step.title,
                   identifier: step.identifier,

--- a/packages/cht_ema_surveys/lib/src/ipaq/presentation/widgets/duration_answer_format.dart
+++ b/packages/cht_ema_surveys/lib/src/ipaq/presentation/widgets/duration_answer_format.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:research_package/model.dart';
+
+class DurationAnswerFormat extends RPAnswerFormat {
+  final int maxHours;
+  final int maxMinutes;
+
+  DurationAnswerFormat({this.maxHours = 23, this.maxMinutes = 59});
+
+  String get identifier => 'duration';
+}
+
+class WheelQuestionBody extends StatefulWidget {
+  final DurationAnswerFormat answerFormat;
+  final void Function(Duration) onResultChange;
+
+  const WheelQuestionBody({
+    required this.answerFormat,
+    required this.onResultChange,
+    super.key,
+  });
+
+  @override
+  WheelQuestionBodyState createState() => WheelQuestionBodyState();
+}
+
+class WheelQuestionBodyState extends State<WheelQuestionBody> {
+  int selectedHour = 0;
+  int selectedMinute = 0;
+
+  void _notifyChange() {
+    final duration = Duration(hours: selectedHour, minutes: selectedMinute);
+    widget.onResultChange(duration);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        _buildWheel(widget.answerFormat.maxHours + 1, 'h', (v) {
+          setState(() => selectedHour = v);
+          _notifyChange();
+        }),
+        const SizedBox(width: 16),
+        _buildWheel(widget.answerFormat.maxMinutes + 1, 'm', (v) {
+          setState(() => selectedMinute = v);
+          _notifyChange();
+        }),
+      ],
+    );
+  }
+
+  Widget _buildWheel(int count, String label, ValueChanged<int> onChanged) {
+    return SizedBox(
+      height: 150,
+      width: 80,
+      child: ListWheelScrollView.useDelegate(
+        itemExtent: 40,
+        onSelectedItemChanged: onChanged,
+        physics: const FixedExtentScrollPhysics(),
+        childDelegate: ListWheelChildBuilderDelegate(
+          childCount: count,
+          builder: (context, index) {
+            return Center(
+              child: Text('$index$label', style: const TextStyle(fontSize: 24)),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/packages/cht_ema_surveys/lib/src/ipaq/presentation/widgets/duration_answer_format.dart
+++ b/packages/cht_ema_surveys/lib/src/ipaq/presentation/widgets/duration_answer_format.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:research_package/model.dart';
 
 class DurationAnswerFormat extends RPAnswerFormat {
@@ -8,66 +7,4 @@ class DurationAnswerFormat extends RPAnswerFormat {
   DurationAnswerFormat({this.maxHours = 23, this.maxMinutes = 59});
 
   String get identifier => 'duration';
-}
-
-class WheelQuestionBody extends StatefulWidget {
-  final DurationAnswerFormat answerFormat;
-  final void Function(Duration) onResultChange;
-
-  const WheelQuestionBody({
-    required this.answerFormat,
-    required this.onResultChange,
-    super.key,
-  });
-
-  @override
-  WheelQuestionBodyState createState() => WheelQuestionBodyState();
-}
-
-class WheelQuestionBodyState extends State<WheelQuestionBody> {
-  int selectedHour = 0;
-  int selectedMinute = 0;
-
-  void _notifyChange() {
-    final duration = Duration(hours: selectedHour, minutes: selectedMinute);
-    widget.onResultChange(duration);
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: [
-        _buildWheel(widget.answerFormat.maxHours + 1, 'h', (v) {
-          setState(() => selectedHour = v);
-          _notifyChange();
-        }),
-        const SizedBox(width: 16),
-        _buildWheel(widget.answerFormat.maxMinutes + 1, 'm', (v) {
-          setState(() => selectedMinute = v);
-          _notifyChange();
-        }),
-      ],
-    );
-  }
-
-  Widget _buildWheel(int count, String label, ValueChanged<int> onChanged) {
-    return SizedBox(
-      height: 150,
-      width: 80,
-      child: ListWheelScrollView.useDelegate(
-        itemExtent: 40,
-        onSelectedItemChanged: onChanged,
-        physics: const FixedExtentScrollPhysics(),
-        childDelegate: ListWheelChildBuilderDelegate(
-          childCount: count,
-          builder: (context, index) {
-            return Center(
-              child: Text('$index$label', style: const TextStyle(fontSize: 24)),
-            );
-          },
-        ),
-      ),
-    );
-  }
 }

--- a/packages/cht_ema_surveys/lib/src/ipaq/presentation/widgets/wheel_answer_format.dart
+++ b/packages/cht_ema_surveys/lib/src/ipaq/presentation/widgets/wheel_answer_format.dart
@@ -1,0 +1,120 @@
+import 'dart:async';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:research_package/model.dart';
+
+class WheelAnswerFormat extends RPAnswerFormat {
+  final List<int> choices;
+
+  WheelAnswerFormat({required this.choices});
+}
+
+class WheelQuestionBody extends StatefulWidget {
+  final WheelAnswerFormat answerFormat;
+  final void Function(dynamic) onResultChange;
+
+  /// Optional previously selected value for this question.
+  /// If provided and found in [answerFormat.choices], the wheel will
+  /// start on that value (used when navigating back to a question).
+  final int? initialValue;
+
+  const WheelQuestionBody({
+    required this.answerFormat,
+    required this.onResultChange,
+    this.initialValue,
+    super.key,
+  });
+
+  @override
+  State<WheelQuestionBody> createState() => _WheelQuestionBodyState();
+}
+
+class _WheelQuestionBodyState extends State<WheelQuestionBody> {
+  late final FixedExtentScrollController _controller;
+
+  void _feedback() {
+    // Use `unawaited` so we don't get discarded_futures warnings.
+    unawaited(SystemSound.play(SystemSoundType.click));
+    unawaited(HapticFeedback.heavyImpact());
+  }
+
+  @override
+  void initState() {
+    super.initState();
+
+    var initialIndex = 0;
+    final initialVal = widget.initialValue;
+    if (initialVal != null) {
+      final idx = widget.answerFormat.choices.indexOf(initialVal);
+      if (idx != -1) {
+        initialIndex = idx;
+      }
+    }
+
+    _controller = FixedExtentScrollController(initialItem: initialIndex);
+  }
+
+  @override
+  void didUpdateWidget(covariant WheelQuestionBody oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (oldWidget.initialValue != widget.initialValue) {
+      var initialIndex = 0;
+      final initialVal = widget.initialValue;
+      if (initialVal != null) {
+        final idx = widget.answerFormat.choices.indexOf(initialVal);
+        if (idx != -1) {
+          initialIndex = idx;
+        }
+      }
+      _controller.jumpToItem(initialIndex);
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 300,
+      child: CupertinoPicker(
+        // 🔧 FIX: it's `scrollController`, not `controller`
+        scrollController: _controller,
+        itemExtent: 50,
+        useMagnifier: true,
+        magnification: 1.6,
+        squeeze: 1,
+        selectionOverlay: Container(
+          margin: const EdgeInsets.symmetric(horizontal: 12),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(20),
+            // Use withValues to avoid deprecation warning
+            color: Colors.grey.withValues(alpha: 0.25),
+          ),
+        ),
+        onSelectedItemChanged: (index) {
+          widget.onResultChange(widget.answerFormat.choices[index]);
+          _feedback();
+        },
+        children: List.generate(
+          widget.answerFormat.choices.length,
+          (index) => Center(
+            child: Text(
+              widget.answerFormat.choices[index].toString(),
+              style: const TextStyle(
+                fontSize: 35,
+                fontWeight: FontWeight.w500,
+                color: Colors.black,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/cht_ema_surveys/lib/src/ipaq/presentation/widgets/wheel_answer_format.dart
+++ b/packages/cht_ema_surveys/lib/src/ipaq/presentation/widgets/wheel_answer_format.dart
@@ -12,7 +12,7 @@ class WheelAnswerFormat extends RPAnswerFormat {
 
 class WheelQuestionBody extends StatefulWidget {
   final WheelAnswerFormat answerFormat;
-  final void Function(dynamic) onResultChange;
+  final ValueChanged<int> onResultChange;
 
   /// Optional previously selected value for this question.
   /// If provided and found in [answerFormat.choices], the wheel will
@@ -83,7 +83,6 @@ class _WheelQuestionBodyState extends State<WheelQuestionBody> {
     return SizedBox(
       height: 300,
       child: CupertinoPicker(
-        // 🔧 FIX: it's `scrollController`, not `controller`
         scrollController: _controller,
         itemExtent: 50,
         useMagnifier: true,

--- a/packages/cht_ema_surveys/pubspec.yaml
+++ b/packages/cht_ema_surveys/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
+  iconify_flutter: ^0.0.7
   intl: any
   research_package:
     git:

--- a/packages/cht_ema_surveys/test/cht_ema_survey_test.dart
+++ b/packages/cht_ema_surveys/test/cht_ema_survey_test.dart
@@ -1,7 +1,37 @@
+import 'package:cht_ema_surveys/cht_ema_surveys.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test('placeholder test', () {
-    expect(true, isTrue);
+  Future<void> pumpIpaqPage(WidgetTester tester, Locale locale) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: locale,
+        localizationsDelegates:
+            ChtEmaSurveysLocalization.localizationsDelegates,
+        supportedLocales: ChtEmaSurveysLocalization.supportedLocales,
+        home: IPAQPage(navigateOnFinish: (_) {}),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('uses English question label in the heading bar', (tester) async {
+    await pumpIpaqPage(tester, const Locale('en'));
+
+    await tester.tap(find.text('Continue'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Question 1'), findsOneWidget);
+    expect(find.text('Pregunta 1'), findsNothing);
+  });
+
+  testWidgets('uses Spanish question label in the heading bar', (tester) async {
+    await pumpIpaqPage(tester, const Locale('es'));
+
+    await tester.tap(find.text('Continuar'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Pregunta 1'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Description

- Presentes International Physical Activity Questionnaire in its EMA adaptation.

## Related Issue(s)

Closes #17 

## Packages Affected

<!-- Mark with an `x` all that apply -->

- [ ] packages/cht_cognition
- [X] packages/cht_ema_surveys
- [ ] general (monorepo / CI / docs)

## Test Plan

<!-- How did you verify this change? Add precise steps and expected outcomes. -->

- [ ] Unit tests added/updated for new/changed logic
- [X] Example app(s) updated and manually tested

## Impact Checklist

<!-- Mark with an `x` all that apply and add details below when checked -->

- [X] **Feature** (new feature)
- [ ] **Improvement** (improved existing feature, refactor or improve code, measurable performance boost)
- [ ] **Fix** (Fixes a bug)
- [ ] **Public API change** (new/changed parameters, return types, or behavior)
- [ ] **Breaking change** (requires host apps to update code)
- [X] **Docs** (README, example apps, or comments)
- [ ] **Internalization** (language strings updated)
- [ ] **CI/config/chore** (melos, CI workflows, release-drafter, dependencies)
- [ ] **Security** (auth, permissions, secrets)
- [ ] **Other changes** not listed above (explain below)

**Details for any checked items above:**

<!-- Briefly explain the change & migration notes if needed. -->

## Pre-merge Checks

- [X] I read the project's code of conduct (see below)
- [X] I read the contributing guide
- [X] Title follows **type(scope): summary** and will auto-label the PR
- [X] Ran locally: `dart run melos bootstrap`
- [X] Ran code formatter: `dart run melos run analyze`
- [X] Ran static analysis: `dart run melos format`
- [X] Ran tests: `dart run melos run test`
- [X] Checked Android example apps build `dart run melos run build_android_examples`
- [X] Checked iOS example apps build `dart run melos run build_ios_examples`

---

### Contributor Guidelines

By opening this PR you agree to follow our Code of Conduct:
https://www.contributor-covenant.org/version/1/4/code-of-conduct/
