### PR TITLE
feat(cognition): add instructions page to G/NG task

### DIFF
--- a/packages/cht_cognition/example/lib/instructionspage.dart
+++ b/packages/cht_cognition/example/lib/instructionspage.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+
+class Instructionspage extends StatelessWidget {
+  const Instructionspage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Instructions')),
+      body: Padding(
+        padding: const EdgeInsets.all(50),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Center(
+              child: Text(
+                "Press the screen when you see green, but don't press when you see red.",
+              ),
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('Start Task'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/packages/cht_cognition/example/lib/main.dart
+++ b/packages/cht_cognition/example/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:cht_cognition/cht_cognition.dart';
+import 'package:cht_cognition_example/instructionspage.dart';
 import 'package:cht_cognition_example/l10n/generated/app_localizations.dart';
 import 'package:flutter/material.dart';
 
@@ -31,7 +32,7 @@ class _ExampleAppState extends State<ExampleApp> {
       ],
       supportedLocales: AppLocalizations.supportedLocales,
       locale: locale,
-      home: HomePage(onLocaleChange: changeLocale),
+      home: Instructionspage(),
     );
   }
 


### PR DESCRIPTION
## Description

This is an instructions page for users to know what to do in the G/NG task.

## Related Issue(s)

Closes #25 

## Packages Affected

<!-- Mark with an `x` all that apply -->

- [x] packages/cht_cognition
- [ ] packages/cht_ema_surveys
- [ ] general (monorepo / CI / docs)

## Test Plan

<!-- How did you verify this change? Add precise steps and expected outcomes. -->

- [ ] Unit tests added/updated for new/changed logic
- [x] Example app(s) updated and manually tested

## Impact Checklist

<!-- Mark with an `x` all that apply and add details below when checked -->

- [x] **Feature** (new feature)
- [ ] **Improvement** (improved existing feature, refactor or improve code, measurable performance boost)
- [ ] **Fix** (Fixes a bug)
- [ ] **Public API change** (new/changed parameters, return types, or behavior)
- [ ] **Breaking change** (requires host apps to update code)
- [x] **Docs** (README, example apps, or comments)
- [ ] **Internalization** (language strings updated)
- [ ] **CI/config/chore** (melos, CI workflows, release-drafter, dependencies)
- [ ] **Security** (auth, permissions, secrets)
- [ ] **Other changes** not listed above (explain below)

**Details for any checked items above:**

<!-- Briefly explain the change & migration notes if needed. -->

## Pre-merge Checks

- [x] I read the project's code of conduct (see below)
- [x] I read the contributing guide
- [x] Title follows **type(scope): summary** and will auto-label the PR
- [x] Ran locally: `dart run melos bootstrap`
- [x] Ran code formatter: `dart run melos run analyze`
- [x] Ran static analysis: `dart run melos format`
- [x] Ran tests: `dart run melos run test`
- [x] Checked Android example apps build `dart run melos run build_android_examples`
- [x] Checked iOS example apps build `dart run melos run build_ios_examples`

---

### Contributor Guidelines

By opening this PR you agree to follow our Code of Conduct:
https://www.contributor-covenant.org/version/1/4/code-of-conduct/
