### PR TITLE
feat(surveys/cognition): add rest message screen between surveys/tasks

### DIFF
--- a/packages/cht_ema_surveys/example/lib/main.dart
+++ b/packages/cht_ema_surveys/example/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:cht_ema_surveys/cht_ema_surveys.dart';
 import 'package:example_surveys/l10n/generated/app_localizations.dart';
+import 'package:example_surveys/rest_page/rest_page.dart';
 import 'package:flutter/material.dart';
 
 void main() {
@@ -31,7 +32,14 @@ class _ExampleAppState extends State<ExampleApp> {
       ],
       supportedLocales: AppLocalizations.supportedLocales,
       locale: locale,
-      home: HomePage(onLocaleChange: changeLocale),
+      home: RestMessageScreen(
+        onContinue: () => Navigator.push(
+          context,
+          MaterialPageRoute<void>(
+            builder: (context) => HomePage(onLocaleChange: changeLocale),
+          ),
+        ),
+      ),
     );
   }
 

--- a/packages/cht_ema_surveys/example/lib/rest_page/rest_page.dart
+++ b/packages/cht_ema_surveys/example/lib/rest_page/rest_page.dart
@@ -3,13 +3,15 @@ import 'package:flutter/material.dart';
 export 'package:cht_ema_surveys/src/core/l10n/cht_rp_localization_loader.dart';
 export 'package:cht_ema_surveys/src/core/l10n/generated/cht_ema_surveys_localization.dart';
 
+const double _restMessageFontSize = 32;
+
 class RestMessageScreen extends StatelessWidget {
   const RestMessageScreen({
-    required this.message,
     required this.onContinue,
     super.key,
-    this.title = 'Rest',
+    this.title = 'mHealth',
     this.buttonText = 'Continue',
+    this.message = 'Rest',
   });
 
   final String title;
@@ -34,10 +36,19 @@ class RestMessageScreen extends StatelessWidget {
               const SizedBox(height: 16),
               Expanded(
                 child: Center(
-                  child: Text(
-                    message,
-                    textAlign: TextAlign.center,
-                    style: theme.textTheme.titleMedium,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        message,
+                        textAlign: TextAlign.center,
+                        style:
+                            (theme.textTheme.titleMedium ?? const TextStyle())
+                                .copyWith(fontSize: _restMessageFontSize),
+                      ),
+                      const SizedBox(height: 24),
+                      const _RestIconBadge(),
+                    ],
                   ),
                 ),
               ),
@@ -51,6 +62,64 @@ class RestMessageScreen extends StatelessWidget {
             ],
           ),
         ),
+      ),
+    );
+  }
+}
+
+class _RestIconBadge extends StatelessWidget {
+  const _RestIconBadge();
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Semantics(
+      label: 'Rest reminder',
+      child: Stack(
+        clipBehavior: Clip.none,
+        alignment: Alignment.center,
+        children: [
+          Container(
+            width: 112,
+            height: 112,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: colorScheme.primaryContainer,
+              border: Border.all(color: colorScheme.outlineVariant, width: 2),
+              boxShadow: const [
+                BoxShadow(
+                  color: Colors.black12,
+                  blurRadius: 18,
+                  offset: Offset(0, 8),
+                ),
+              ],
+            ),
+            child: Icon(
+              Icons.schedule_rounded,
+              size: 56,
+              color: colorScheme.onPrimaryContainer,
+            ),
+          ),
+          Positioned(
+            right: -2,
+            bottom: 6,
+            child: Container(
+              width: 34,
+              height: 34,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: colorScheme.secondaryContainer,
+                border: Border.all(color: colorScheme.surface, width: 3),
+              ),
+              child: Icon(
+                Icons.auto_awesome_rounded,
+                size: 18,
+                color: colorScheme.onSecondaryContainer,
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/packages/cht_ema_surveys/example/lib/rest_page/rest_page.dart
+++ b/packages/cht_ema_surveys/example/lib/rest_page/rest_page.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+
+export 'package:cht_ema_surveys/src/core/l10n/cht_rp_localization_loader.dart';
+export 'package:cht_ema_surveys/src/core/l10n/generated/cht_ema_surveys_localization.dart';
+
+class RestMessageScreen extends StatelessWidget {
+  const RestMessageScreen({
+    required this.message,
+    required this.onContinue,
+    super.key,
+    this.title = 'Rest',
+    this.buttonText = 'Continue',
+  });
+
+  final String title;
+  final String message;
+  final String buttonText;
+
+  /// Parent decides what "next step" means (push next route, resume task, etc.)
+  final VoidCallback onContinue;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(title, style: theme.textTheme.headlineSmall),
+              const SizedBox(height: 16),
+              Expanded(
+                child: Center(
+                  child: Text(
+                    message,
+                    textAlign: TextAlign.center,
+                    style: theme.textTheme.titleMedium,
+                  ),
+                ),
+              ),
+              SizedBox(
+                height: 48,
+                child: ElevatedButton(
+                  onPressed: onContinue,
+                  child: Text(buttonText),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Description

It tells participants to rest in between tasks or surveys.

## Related Issue(s)

Closes #24 

## Packages Affected

<!-- Mark with an `x` all that apply -->

- [x] packages/cht_cognition
- [x] packages/cht_ema_surveys
- [ ] general (monorepo / CI / docs)

## Test Plan

<!-- How did you verify this change? Add precise steps and expected outcomes. -->

- [ ] Unit tests added/updated for new/changed logic
- [x] Example app(s) updated and manually tested

## Impact Checklist

<!-- Mark with an `x` all that apply and add details below when checked -->

- [x] **Feature** (new feature)
- [ ] **Improvement** (improved existing feature, refactor or improve code, measurable performance boost)
- [ ] **Fix** (Fixes a bug)
- [ ] **Public API change** (new/changed parameters, return types, or behavior)
- [ ] **Breaking change** (requires host apps to update code)
- [x] **Docs** (README, example apps, or comments)
- [ ] **Internalization** (language strings updated)
- [ ] **CI/config/chore** (melos, CI workflows, release-drafter, dependencies)
- [ ] **Security** (auth, permissions, secrets)
- [ ] **Other changes** not listed above (explain below)

**Details for any checked items above:**

<!-- Briefly explain the change & migration notes if needed. -->

## Pre-merge Checks

- [x] I read the project's code of conduct (see below)
- [x] I read the contributing guide
- [x] Title follows **type(scope): summary** and will auto-label the PR
- [x] Ran locally: `dart run melos bootstrap`
- [x] Ran code formatter: `dart run melos run analyze`
- [x] Ran static analysis: `dart run melos format`
- [x] Ran tests: `dart run melos run test`
- [x] Checked Android example apps build `dart run melos run build_android_examples`
- [x] Checked iOS example apps build `dart run melos run build_ios_examples`

---

### Contributor Guidelines

By opening this PR you agree to follow our Code of Conduct:
https://www.contributor-covenant.org/version/1/4/code-of-conduct/
