### PR TITLE
feat(cognition/surveys): add TaskListPage

### DIFF
--- a/packages/cht_cognition/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/packages/cht_cognition/example/ios/Flutter/AppFrameworkInfo.plist
@@ -20,7 +20,5 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>MinimumOSVersion</key>
-  <string>13.0</string>
 </dict>
 </plist>

--- a/packages/cht_cognition/example/ios/Runner/AppDelegate.swift
+++ b/packages/cht_cognition/example/ios/Runner/AppDelegate.swift
@@ -2,12 +2,15 @@ import Flutter
 import UIKit
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
-    GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+    GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
   }
 }

--- a/packages/cht_cognition/example/ios/Runner/Info.plist
+++ b/packages/cht_cognition/example/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
@@ -24,6 +26,29 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>flutter</string>
+					<key>UISceneDelegateClassName</key>
+					<string>FlutterSceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -41,9 +66,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>CADisableMinimumFrameDurationOnPhone</key>
-	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
 </dict>
 </plist>

--- a/packages/cht_ema_surveys/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/packages/cht_ema_surveys/example/ios/Flutter/AppFrameworkInfo.plist
@@ -20,7 +20,5 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>MinimumOSVersion</key>
-  <string>13.0</string>
 </dict>
 </plist>

--- a/packages/cht_ema_surveys/example/ios/Runner/AppDelegate.swift
+++ b/packages/cht_ema_surveys/example/ios/Runner/AppDelegate.swift
@@ -2,12 +2,15 @@ import Flutter
 import UIKit
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
-    GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+    GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
   }
 }

--- a/packages/cht_ema_surveys/example/ios/Runner/Info.plist
+++ b/packages/cht_ema_surveys/example/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
@@ -24,6 +26,29 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>flutter</string>
+					<key>UISceneDelegateClassName</key>
+					<string>FlutterSceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -41,9 +66,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>CADisableMinimumFrameDurationOnPhone</key>
-	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
 </dict>
 </plist>

--- a/packages/cht_ema_surveys/example/lib/main.dart
+++ b/packages/cht_ema_surveys/example/lib/main.dart
@@ -1,4 +1,5 @@
-import 'package:cht_ema_surveys/cht_ema_surveys.dart';
+import 'package:cht_cognition/cht_cognition.dart' as cognition;
+import 'package:cht_ema_surveys/cht_ema_surveys.dart' as surveys;
 import 'package:example_surveys/l10n/generated/app_localizations.dart';
 import 'package:example_surveys/task_list/task_list.dart';
 import 'package:flutter/material.dart';
@@ -26,13 +27,14 @@ class _ExampleAppState extends State<ExampleApp> {
         useMaterial3: true,
       ),
       localizationsDelegates: [
-        ChtEmaSurveysLocalization.delegate,
-        ChtRpLocalizationLoader.rpDelegate,
+        cognition.ChtCognitionLocalization.delegate,
+        surveys.ChtEmaSurveysLocalization.delegate,
+        surveys.ChtRpLocalizationLoader.rpDelegate,
         ...AppLocalizations.localizationsDelegates,
       ],
       supportedLocales: AppLocalizations.supportedLocales,
       locale: locale,
-      home: const TaskListPage(),
+      home: HomePage(onLocaleChange: changeLocale),
     );
   }
 

--- a/packages/cht_ema_surveys/example/lib/main.dart
+++ b/packages/cht_ema_surveys/example/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:cht_ema_surveys/cht_ema_surveys.dart';
 import 'package:example_surveys/l10n/generated/app_localizations.dart';
+import 'package:example_surveys/task_list/task_list.dart';
 import 'package:flutter/material.dart';
 
 void main() {
@@ -31,7 +32,7 @@ class _ExampleAppState extends State<ExampleApp> {
       ],
       supportedLocales: AppLocalizations.supportedLocales,
       locale: locale,
-      home: HomePage(onLocaleChange: changeLocale),
+      home: const TaskListPage(),
     );
   }
 
@@ -76,35 +77,7 @@ class _HomePageState extends State<HomePage> {
           ),
         ],
       ),
-      body: const SurveyList(),
-    );
-  }
-}
-
-class SurveyList extends StatelessWidget {
-  const SurveyList({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    final localizations = AppLocalizations.of(context);
-    return Scaffold(
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            ElevatedButton(
-              onPressed: () => Navigator.push(
-                context,
-                MaterialPageRoute<void>(builder: (context) => SurveyPage()),
-              ),
-              child: Text(
-                localizations.homeMessage,
-                style: Theme.of(context).textTheme.headlineMedium,
-              ),
-            ),
-          ],
-        ),
-      ),
+      body: const TaskListPage(),
     );
   }
 }

--- a/packages/cht_ema_surveys/example/lib/task_list/task_list.dart
+++ b/packages/cht_ema_surveys/example/lib/task_list/task_list.dart
@@ -1,0 +1,184 @@
+import 'package:flutter/material.dart';
+
+const List<TaskListItem> taskListItems = <TaskListItem>[
+  TaskListItem(
+    id: 'n_back',
+    title: 'N-Back',
+    scope: 'Cognition',
+    description: 'Working memory task',
+    icon: Icons.psychology_alt_outlined,
+  ),
+  TaskListItem(
+    id: 'go_no_go',
+    title: 'Go/No-Go',
+    scope: 'Cognition',
+    description: 'Response inhibition task',
+    icon: Icons.touch_app_outlined,
+  ),
+  TaskListItem(
+    id: 'trail_making',
+    title: 'Trail Making',
+    scope: 'Cognition',
+    description: 'Cognitive flexibility task',
+    icon: Icons.route_outlined,
+  ),
+  TaskListItem(
+    id: 'ipaq',
+    title: 'IPAQ',
+    scope: 'Survey',
+    description: 'International Physical Activity Questionnaire',
+    icon: Icons.directions_run_outlined,
+  ),
+  TaskListItem(
+    id: 'erq',
+    title: 'ERQ',
+    scope: 'Survey',
+    description: 'Emotion Regulation Questionnaire',
+    icon: Icons.mood_outlined,
+  ),
+];
+
+class TaskListPage extends StatelessWidget {
+  const TaskListPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ColoredBox(
+      color: Theme.of(context).scaffoldBackgroundColor,
+      child: SafeArea(
+        child: LayoutBuilder(
+          builder: (BuildContext context, BoxConstraints constraints) {
+            final crossAxisCount = _crossAxisCountForWidth(
+              constraints.maxWidth,
+            );
+            return Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Text(
+                    'Available tasks',
+                    style: Theme.of(context).textTheme.headlineSmall,
+                  ),
+                  const SizedBox(height: 16),
+                  Expanded(
+                    child: GridView.builder(
+                      itemCount: taskListItems.length,
+                      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                        crossAxisCount: crossAxisCount,
+                        crossAxisSpacing: 12,
+                        mainAxisSpacing: 12,
+                        childAspectRatio: 2.8,
+                      ),
+                      itemBuilder: (BuildContext context, int index) {
+                        final item = taskListItems[index];
+                        return TaskTile(
+                          key: Key('task-tile-${item.id}'),
+                          item: item,
+                          onTap: () => _showTaskPlaceholder(context, item),
+                        );
+                      },
+                    ),
+                  ),
+                ],
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  int _crossAxisCountForWidth(double width) {
+    if (width >= 1000) return 3;
+    if (width >= 600) return 2;
+    return 1;
+  }
+
+  void _showTaskPlaceholder(BuildContext context, TaskListItem item) {
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        SnackBar(content: Text('${item.title} task is not available yet.')),
+      );
+  }
+}
+
+class TaskTile extends StatelessWidget {
+  final TaskListItem item;
+  final VoidCallback? onTap;
+
+  const TaskTile({required this.item, this.onTap, super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Row(
+            children: <Widget>[
+              DecoratedBox(
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.surfaceContainerHighest,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: SizedBox.square(dimension: 48, child: Icon(item.icon)),
+              ),
+              const SizedBox(width: 16),
+              Expanded(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Text(
+                      item.title,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      item.scope,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context).textTheme.labelLarge,
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      item.description,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 8),
+              const Icon(Icons.chevron_right),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class TaskListItem {
+  final String id;
+  final String title;
+  final String scope;
+  final String description;
+  final IconData icon;
+
+  const TaskListItem({
+    required this.id,
+    required this.title,
+    required this.scope,
+    required this.description,
+    required this.icon,
+  });
+}

--- a/packages/cht_ema_surveys/example/lib/task_list/task_list.dart
+++ b/packages/cht_ema_surveys/example/lib/task_list/task_list.dart
@@ -1,40 +1,23 @@
+import 'package:cht_cognition/cht_cognition.dart' as cognition;
+import 'package:cht_ema_surveys/cht_ema_surveys.dart' as surveys;
 import 'package:flutter/material.dart';
 
 const List<TaskListItem> taskListItems = <TaskListItem>[
-  TaskListItem(
-    id: 'n_back',
-    title: 'N-Back',
-    scope: 'Cognition',
-    description: 'Working memory task',
-    icon: Icons.psychology_alt_outlined,
-  ),
   TaskListItem(
     id: 'go_no_go',
     title: 'Go/No-Go',
     scope: 'Cognition',
     description: 'Response inhibition task',
     icon: Icons.touch_app_outlined,
+    destination: TaskListDestination.goNoGo,
   ),
   TaskListItem(
-    id: 'trail_making',
-    title: 'Trail Making',
-    scope: 'Cognition',
-    description: 'Cognitive flexibility task',
-    icon: Icons.route_outlined,
-  ),
-  TaskListItem(
-    id: 'ipaq',
-    title: 'IPAQ',
+    id: 'survey',
+    title: 'Survey',
     scope: 'Survey',
-    description: 'International Physical Activity Questionnaire',
-    icon: Icons.directions_run_outlined,
-  ),
-  TaskListItem(
-    id: 'erq',
-    title: 'ERQ',
-    scope: 'Survey',
-    description: 'Emotion Regulation Questionnaire',
+    description: 'Example EMA survey',
     icon: Icons.mood_outlined,
+    destination: TaskListDestination.survey,
   ),
 ];
 
@@ -75,7 +58,7 @@ class TaskListPage extends StatelessWidget {
                         return TaskTile(
                           key: Key('task-tile-${item.id}'),
                           item: item,
-                          onTap: () => _showTaskPlaceholder(context, item),
+                          onTap: () => _openTask(context, item.destination),
                         );
                       },
                     ),
@@ -95,12 +78,25 @@ class TaskListPage extends StatelessWidget {
     return 1;
   }
 
-  void _showTaskPlaceholder(BuildContext context, TaskListItem item) {
-    ScaffoldMessenger.of(context)
-      ..hideCurrentSnackBar()
-      ..showSnackBar(
-        SnackBar(content: Text('${item.title} task is not available yet.')),
-      );
+  void _openTask(BuildContext context, TaskListDestination destination) {
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (BuildContext context) {
+          return switch (destination) {
+            TaskListDestination.goNoGo => cognition.GoNoGoTask(
+              processData: _printCognitiveData,
+              participantId: 'p1',
+              sessionId: 's1',
+              nTrials: 20,
+              goProbability: .75,
+              trialTimeoutDuration: const Duration(milliseconds: 750),
+              restEveryNTrials: 10,
+            ),
+            TaskListDestination.survey => surveys.SurveyPage(),
+          };
+        },
+      ),
+    );
   }
 }
 
@@ -173,6 +169,7 @@ class TaskListItem {
   final String scope;
   final String description;
   final IconData icon;
+  final TaskListDestination destination;
 
   const TaskListItem({
     required this.id,
@@ -180,5 +177,12 @@ class TaskListItem {
     required this.scope,
     required this.description,
     required this.icon,
+    required this.destination,
   });
+}
+
+enum TaskListDestination { goNoGo, survey }
+
+void _printCognitiveData(cognition.CognitiveData data) {
+  debugPrint(data.toString());
 }

--- a/packages/cht_ema_surveys/example/pubspec.yaml
+++ b/packages/cht_ema_surveys/example/pubspec.yaml
@@ -9,6 +9,8 @@ environment:
   sdk: ^3.9.0
 
 dependencies:
+  cht_cognition:
+    path: ../../cht_cognition
   cht_ema_surveys:
     path: ../../cht_ema_surveys
   cupertino_icons: ^1.0.6


### PR DESCRIPTION
## Description

Implements a task list page so that the user can access the different cognitive tasks or surveys.

## Related Issue(s)

Closes #43 

## Packages Affected

<!-- Mark with an `x` all that apply -->

- [X] packages/cht_cognition
- [X] packages/cht_ema_surveys
- [ ] general (monorepo / CI / docs)

## Test Plan

<!-- How did you verify this change? Add precise steps and expected outcomes. -->

- [ ] Unit tests added/updated for new/changed logic
- [X] Example app(s) updated and manually tested

## Impact Checklist

<!-- Mark with an `x` all that apply and add details below when checked -->

- [X] **Feature** (new feature)
- [ ] **Improvement** (improved existing feature, refactor or improve code, measurable performance boost)
- [ ] **Fix** (Fixes a bug)
- [ ] **Public API change** (new/changed parameters, return types, or behavior)
- [ ] **Breaking change** (requires host apps to update code)
- [X] **Docs** (README, example apps, or comments)
- [ ] **Internalization** (language strings updated)
- [ ] **CI/config/chore** (melos, CI workflows, release-drafter, dependencies)
- [ ] **Security** (auth, permissions, secrets)
- [ ] **Other changes** not listed above (explain below)

**Details for any checked items above:**

<!-- Briefly explain the change & migration notes if needed. -->

## Pre-merge Checks

- [X] I read the project's code of conduct (see below)
- [X] I read the contributing guide
- [X] Title follows **type(scope): summary** and will auto-label the PR
- [X] Ran locally: `dart run melos bootstrap`
- [X] Ran code formatter: `dart run melos run analyze`
- [X] Ran static analysis: `dart run melos format`
- [X] Ran tests: `dart run melos run test`
- [X] Checked Android example apps build `dart run melos run build_android_examples`
- [X] Checked iOS example apps build `dart run melos run build_ios_examples`

---

### Contributor Guidelines

By opening this PR you agree to follow our Code of Conduct:
https://www.contributor-covenant.org/version/1/4/code-of-conduct/
